### PR TITLE
[Require-image-digests] Operator pod with image from non prod should be able to use a tag

### DIFF
--- a/policies/other/require-image-digest/require-image-digest.yaml
+++ b/policies/other/require-image-digest/require-image-digest.yaml
@@ -35,14 +35,13 @@ spec:
                 - "sls-*"
                 - "ibm-sls"
       preconditions:
-        all:
-          - key: "{{request.object.metadata.labels.\"app.kubernetes.io/managed-by\"}}"
+        any:
+          - key: "{{ request.object.metadata.labels.\"app.kubernetes.io/managed-by\" || '' }}"
             operator: NotEquals
             value: olm
-          - key: "{{request.object.spec.containers[*].image}}"
-            operator: AnyNotIn
-            value:
-              - "*cp.icr.io*"
+          - key: "{{ (request.object.metadata.labels.\"app.kubernetes.io/managed-by\" == 'olm') && (request.object.spec.containers[*].image | join(',') | contains(@, 'cp.icr.io')) }}"
+            operator: Equals
+            value: true
       validate:
         message: "Images must use checksums rather than tags."
         pattern:

--- a/policies/other/require-image-digest/require-image-digest.yaml
+++ b/policies/other/require-image-digest/require-image-digest.yaml
@@ -39,7 +39,7 @@ spec:
           - key: "{{ request.object.metadata.labels.\"app.kubernetes.io/managed-by\" || '' }}"
             operator: NotEquals
             value: olm
-          - key: "{{ (request.object.metadata.labels.\"app.kubernetes.io/managed-by\" == 'olm') && (request.object.spec.containers[*].image | join(',') | contains(@, 'cp.icr.io')) }}"
+          - key: "{{ (request.object.metadata.labels.\"app.kubernetes.io/managed-by\" == 'olm') && (request.object.spec.containers[*].image | join(',') | contains(@, 'icr.io')) }}"
             operator: Equals
             value: true
       validate:

--- a/policies/other/require-image-digest/require-image-digest.yaml
+++ b/policies/other/require-image-digest/require-image-digest.yaml
@@ -34,6 +34,15 @@ spec:
                 - "mas-*-visualinspection"
                 - "sls-*"
                 - "ibm-sls"
+      preconditions:
+        all:
+          - key: "{{request.object.metadata.labels.\"app.kubernetes.io/managed-by\"}}"
+            operator: NotEquals
+            value: olm
+          - key: "{{request.object.spec.containers[*].image}}"
+            operator: AnyNotIn
+            value:
+              - "*cp.icr.io*"
       validate:
         message: "Images must use checksums rather than tags."
         pattern:


### PR DESCRIPTION
Policy for internal use should follow this rule:
- if registry the image comes from is NOT [cp.icr.io](http://cp.icr.io/) AND it's an operator image