### PR TITLE
Excluding truststore operator from require-image-digests

### DIFF
--- a/policies/other/require-image-digest/require-image-digest.yaml
+++ b/policies/other/require-image-digest/require-image-digest.yaml
@@ -36,6 +36,9 @@ spec:
                 - "ibm-sls"
       preconditions:
         any:
+          - key: "{{ request.object.metadata.labels.\"app.kubernetes.io/instance\" || '' }}"
+            operator: NotEquals
+            value: ibm-truststore-mgr
           - key: "{{ request.object.metadata.labels.\"app.kubernetes.io/managed-by\" || '' }}"
             operator: NotEquals
             value: olm


### PR DESCRIPTION
Truststore operator is OLM managed but may not use image digests