### PR TITLE
Add exception to skip policy validation for manage admin builds

### DIFF
--- a/policies/components/other/require-pod-probes-unique/require-pod-probes-unique.yaml
+++ b/policies/components/other/require-pod-probes-unique/require-pod-probes-unique.yaml
@@ -39,3 +39,11 @@ spec:
               - key: "{{ request.object.spec.template.spec.containers[?readinessProbe==livenessProbe] | length(@) }}"
                 operator: GreaterThan
                 value: "0"
+      exclude:
+        resources:
+          kinds:
+            - Pod
+          selector:
+            matchExpressions:
+              - key: "openshift.io/build.name"
+                operator: Exists

--- a/policies/components/other/require-pod-probes/require-pod-probes.yaml
+++ b/policies/components/other/require-pod-probes/require-pod-probes.yaml
@@ -45,6 +45,8 @@ spec:
             matchExpressions:
               - key: "job-name"
                 operator: Exists
+              - key: "openshift.io/build.name"
+                operator: Exists
       validate:
         message: "Liveness & readiness probes are required for all containers (startup probes are optional)."
         foreach:

--- a/policies/components/other/require-pod-probes/require-pod-probes.yaml
+++ b/policies/components/other/require-pod-probes/require-pod-probes.yaml
@@ -38,15 +38,21 @@ spec:
                   - key: ibm.com/kyverno
                     operator: Exists
       exclude:
-        resources:
-          kinds:
-            - Pod
-          selector:
-            matchExpressions:
-              - key: "job-name"
-                operator: Exists
-              - key: "openshift.io/build.name"
-                operator: Exists
+        any:
+          - resources:
+              kinds:
+                - Pod
+              selector:
+                matchExpressions:
+                  - key: "job-name"
+                    operator: Exists
+          - resources:
+              kinds:
+                - Pod
+              selector:
+                matchExpressions:
+                  - key: "openshift.io/build.name"
+                    operator: Exists
       validate:
         message: "Liveness & readiness probes are required for all containers (startup probes are optional)."
         foreach:

--- a/policies/components/scheduling/disallow-node-selection/disallow-node-selection.yaml
+++ b/policies/components/scheduling/disallow-node-selection/disallow-node-selection.yaml
@@ -35,6 +35,14 @@ spec:
         pattern:
           spec:
             X(nodeSelector): "null"
+      exclude:
+        resources:
+          kinds:
+            - Pod
+          selector:
+            matchExpressions:
+              - key: "openshift.io/build.name"
+                operator: Exists            
 
     - name: restrict-nodename
       preconditions:
@@ -58,6 +66,13 @@ spec:
                 matchExpressions:
                   - key: ibm.com/kyverno
                     operator: Exists
+          - resources:
+            kinds:
+              - Pod
+            selector:
+              matchExpressions:
+                - key: "openshift.io/build.name"
+                  operator: Exists
       validate:
         message: Setting the nodeName field is prohibited.
         pattern:

--- a/policies/components/scheduling/disallow-node-selection/disallow-node-selection.yaml
+++ b/policies/components/scheduling/disallow-node-selection/disallow-node-selection.yaml
@@ -35,6 +35,9 @@ spec:
         pattern:
           spec:
             X(nodeSelector): "null"
+      # Builds could require higher number of resources which we provide customization through podTemplates. 
+      # If the higher resources required are not available on the node, nodeSelector podTemplate option is given to the customer to allow them to select the node on which build should run.
+      # If we remove the nodeSelector option from BuildConfig, they won't be able to select the node and builds may start to fail if resources are exhausted.
       exclude:
         resources:
           kinds:
@@ -59,6 +62,9 @@ spec:
                 matchExpressions:
                   - key: ibm.com/kyverno
                     operator: Exists
+      # Builds could require higher number of resources which we provide customization through podTemplates. 
+      # If the higher resources required are not available on the node, nodeSelector podTemplate option is given to the customer to allow them to select the node on which build should run.
+      # If we remove the nodeSelector option from BuildConfig, they won't be able to select the node and builds may start to fail if resources are exhausted.
       exclude:
         any:
           - resources:

--- a/policies/components/security-context/disallow-privilege-escalation/disallow-privilege-escalation.yaml
+++ b/policies/components/security-context/disallow-privilege-escalation/disallow-privilege-escalation.yaml
@@ -44,3 +44,11 @@ spec:
             containers:
               - securityContext:
                   allowPrivilegeEscalation: "false"
+      exclude:
+        resources:
+          kinds:
+            - Pod
+          selector:
+            matchExpressions:
+              - key: "openshift.io/build.name"
+                operator: Exists

--- a/policies/components/security-context/disallow-privilege-escalation/disallow-privilege-escalation.yaml
+++ b/policies/components/security-context/disallow-privilege-escalation/disallow-privilege-escalation.yaml
@@ -44,6 +44,8 @@ spec:
             containers:
               - securityContext:
                   allowPrivilegeEscalation: "false"
+      # Documentation shows that securityContext is not supported in the builds: 
+      # https://docs.openshift.com/container-platform/latest/rest_api/workloads_apis/buildconfig-build-openshift-io-v1.html
       exclude:
         resources:
           kinds:

--- a/policies/components/security-context/disallow-run-as-root-user/disallow-run-as-root-user.yaml
+++ b/policies/components/security-context/disallow-run-as-root-user/disallow-run-as-root-user.yaml
@@ -45,3 +45,11 @@ spec:
             containers:
               - =(securityContext):
                   =(runAsUser): ">0"
+      exclude:
+        resources:
+          kinds:
+            - Pod
+          selector:
+            matchExpressions:
+              - key: "openshift.io/build.name"
+                operator: Exists

--- a/policies/components/security-context/disallow-run-as-root-user/disallow-run-as-root-user.yaml
+++ b/policies/components/security-context/disallow-run-as-root-user/disallow-run-as-root-user.yaml
@@ -45,6 +45,8 @@ spec:
             containers:
               - =(securityContext):
                   =(runAsUser): ">0"
+      # Documentation shows that securityContext is not supported in the builds: 
+      # https://docs.openshift.com/container-platform/latest/rest_api/workloads_apis/buildconfig-build-openshift-io-v1.html
       exclude:
         resources:
           kinds:

--- a/policies/components/security-context/require-drop-all-capabilities/require-drop-all-capabilities.yaml
+++ b/policies/components/security-context/require-drop-all-capabilities/require-drop-all-capabilities.yaml
@@ -39,3 +39,11 @@ spec:
                   - key: ALL
                     operator: AnyNotIn
                     value: "{{ element.securityContext.capabilities.drop[].to_upper(@) || `[]` }}"
+      exclude:
+        resources:
+          kinds:
+            - Pod
+          selector:
+            matchExpressions:
+              - key: "openshift.io/build.name"
+                operator: Exists

--- a/policies/components/security-context/require-drop-all-capabilities/require-drop-all-capabilities.yaml
+++ b/policies/components/security-context/require-drop-all-capabilities/require-drop-all-capabilities.yaml
@@ -39,6 +39,8 @@ spec:
                   - key: ALL
                     operator: AnyNotIn
                     value: "{{ element.securityContext.capabilities.drop[].to_upper(@) || `[]` }}"
+      # Documentation shows that securityContext is not supported in the builds: 
+      # https://docs.openshift.com/container-platform/latest/rest_api/workloads_apis/buildconfig-build-openshift-io-v1.html
       exclude:
         resources:
           kinds:

--- a/policies/components/security-context/require-run-as-nonroot/require-run-as-nonroot.yaml
+++ b/policies/components/security-context/require-run-as-nonroot/require-run-as-nonroot.yaml
@@ -56,3 +56,12 @@ spec:
               containers:
                 - securityContext:
                     runAsNonRoot: "true"
+      exclude:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              selector:
+                matchExpressions:
+                  - key: "openshift.io/build.name"
+                    operator: Exists

--- a/policies/components/security-context/require-run-as-nonroot/require-run-as-nonroot.yaml
+++ b/policies/components/security-context/require-run-as-nonroot/require-run-as-nonroot.yaml
@@ -56,6 +56,8 @@ spec:
               containers:
                 - securityContext:
                     runAsNonRoot: "true"
+      # Documentation shows that securityContext is not supported in the builds: 
+      # https://docs.openshift.com/container-platform/latest/rest_api/workloads_apis/buildconfig-build-openshift-io-v1.html
       exclude:
         any:
           - resources:


### PR DESCRIPTION
The Manage Operator triggers admin and server bundle builds using BuildConfigs, which generate images that run as containers. Since these builds execute in transient pods, they can be excluded from policy compliance checks. Therefore, this PR has been created to exclude admin builds from Kyverno policy validation.

Slack discussion: 
https://ibm-mas.slack.com/archives/C07F4DXLDGS/p1758879823844879