### PR TITLE
[patch] Add optional namespace parameter

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--namespace",
+        action="store",
+        default=None,
+        help="Kubernetes namespace to test policies in"
+    )
+
+@pytest.fixture
+def namespace(request):
+    return request.config.getoption("--namespace")

--- a/test_policies.py
+++ b/test_policies.py
@@ -24,11 +24,11 @@ def get_policy_names():
     return policyNames
 
 @pytest.mark.parametrize("policyName", get_policy_names())
-def testPolicies(policyName):
+def testPolicies(policyName, namespace):
     policyReports = dynClient.resources.get(
         api_version="wgpolicyk8s.io/v1alpha2", kind="PolicyReport"
     )
-    reports = policyReports.get(namespace=None)
+    reports = policyReports.get(namespace=namespace)
     failures = []
     policyMatchCount = 0
     for report in reports.items:


### PR DESCRIPTION
## Description
This change add  optional namespace parameter so test can be run against a specific namespace (core, manage, mvi, etc..) versus all namespaces.

**Impact:** No impact, default behavior stays the same,

## Related Issues
- https://jsw.ibm.com/browse/MASMVI-2983

## How Has This Been Tested?
Running pytest with argument
```
  pytest -vv --tb=long --showlocals -r A test_policies.py \
                                             --namespace=${env.MVI_NAMESPACE} \
                                             --junitxml=pytest-report.xml
```

**Jenkins Build Reference:** https://sys-powerai-test-jenkins.swg-devops.com/job/PowerAI/job/PowerAI-Vision-Test/view/Monitor%20View/job/dev-kyverno-automation/84/

## Link to Automated testcase created?
n/a