### PR TITLE
[patch] Added manage build pods into exception list

### DIFF
--- a/policies/components/other/require-ephemeral-storage-sizelimit/require-ephemeral-storage-sizelimit.yaml
+++ b/policies/components/other/require-ephemeral-storage-sizelimit/require-ephemeral-storage-sizelimit.yaml
@@ -27,6 +27,8 @@ spec:
                 matchExpressions:
                   - key: ibm.com/kyverno
                     operator: Exists
+      # Documentation shows that there is no way to define sizeLimit for the emptyDir created by builder:
+      # https://docs.openshift.com/container-platform/latest/rest_api/workloads_apis/buildconfig-build-openshift-io-v1.html
       exclude:
         any:
           - resources:

--- a/policies/components/other/require-ephemeral-storage-sizelimit/require-ephemeral-storage-sizelimit.yaml
+++ b/policies/components/other/require-ephemeral-storage-sizelimit/require-ephemeral-storage-sizelimit.yaml
@@ -27,6 +27,15 @@ spec:
                 matchExpressions:
                   - key: ibm.com/kyverno
                     operator: Exists
+      exclude:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              selector:
+                matchExpressions:
+                  - key: "openshift.io/build.name"
+                    operator: Exists
       validate:
         message: "All emptyDir volumes must define a sizeLimit to prevent unbounded storage consumption."
         deny:


### PR DESCRIPTION
Pods created by the manage build configuration contain several emptyDir volumes that are not being explicitly created by operator, which causes policy violations. These pods have been added to the exception list to bypass the policy checks. Additionally, Ford does not utilize manage builds in their environment, they are using `skipBuildImage` and doing whole process outside.

These emptyDir are added by Openshift BuildConfig buildah builder when creating the build pods. These are created without any sizeLimit  hence, the policy is failing.
```
    - name: buildworkdir
      emptyDir: {}
    - name: container-storage-root
      emptyDir: {}
    - name: container-storage-run
      emptyDir: {}
    - name: build-blob-cache
      emptyDir: {}
```
We checked documentation or any other resource using BOB whether we can define sizeLimit  in any way but there doesn't seem to be one.
https://docs.openshift.com/container-platform/latest/rest_api/workloads_apis/buildconfig-build-openshift-io-v1.html

We can only control the overall ephemeral storage limit of the pod via resources, which we already have as below:
```
spec:
  resources:
    limits:
      cpu: '3'
      ephemeral-storage: 100Gi
      memory: 4Gi
    requests:
      cpu: '1'
      ephemeral-storage: 30Gi
      memory: 1Gi
```